### PR TITLE
Fixing user object and display name

### DIFF
--- a/pages/auth/signin.vue
+++ b/pages/auth/signin.vue
@@ -33,7 +33,7 @@ export default {
     ...mapActions('modules/user', [ 'login' ]),
     submit () {
       firebaseApp.auth().signInWithEmailAndPassword(this.email, this.password).then((firebaseUser) => {
-        return this.login(firebaseUser.uid)
+        return this.login(firebaseUser)
       }).then(() => {
         this.$router.push('/protected')
       }).catch((error) => {

--- a/pages/auth/signup.vue
+++ b/pages/auth/signup.vue
@@ -33,7 +33,7 @@ export default {
       try {
         const firebaseUser = await firebaseApp.auth().createUserWithEmailAndPassword(this.email, this.password)
         await this.writeUserData(firebaseUser.uid, firebaseUser.email)
-        await this.login(firebaseUser.uid)
+        await this.login(firebaseUser)
         this.$router.push('/protected')
       } catch (error) {
         console.log(error.message)
@@ -82,4 +82,3 @@ export default {
   }
 
 </style>
-

--- a/pages/protected/index.vue
+++ b/pages/protected/index.vue
@@ -7,7 +7,7 @@
       <div>
         User ID: {{ uid }}
       </div>
-      <h3>Current User: {{user.name}}</h3>
+      <h3>Current User: {{user.name||user.email}}</h3>
       <img v-if="user.avatar" :src="user.avatar" alt="">
       <div>
         All DB Users: {{ allusers }}


### PR DESCRIPTION
The login action was only passing in the uid when the store was request the full user object. Also updated the display name of the logged in user to default to the email incase the name of the user wasn't set. It was showing a blank space so it looked like the demo was broken.